### PR TITLE
Add default new file behaviour if user does not specify file name

### DIFF
--- a/advanced_new_file/commands/command_base.py
+++ b/advanced_new_file/commands/command_base.py
@@ -304,6 +304,8 @@ class AdvancedNewFileBase(object):
     def on_done(self, input_string):
         if len(input_string) != 0:
             self.entered_filename(input_string)
+        else:
+            self.window.new_file()
 
         self.clear()
         self.refresh_sidebar()


### PR DESCRIPTION
It would be cool to still have the default new file behaviour available for cases where you actually don't want to specify the new file title/location or even save it later (temp paste data). 

Currently there are two ways to get out ot of the ANF input: pressing either escape or enter keys.

I propose to use enter to fall back to default behaviour. 